### PR TITLE
EnterVillageUseCaseを実装

### DIFF
--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/VillageId.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/VillageId.kt
@@ -4,8 +4,23 @@ import java.util.UUID
 
 data class VillageId(val value: UUID) {
     companion object {
+        /**
+         * 村IDを生成する
+         *
+         * @return 村ID
+         */
         fun generate(): VillageId {
             return VillageId(UUID.randomUUID())
+        }
+
+        /**
+         * 村IDを生成する
+         *
+         * @param value 村IDの文字列
+         * @return 村ID
+         */
+        fun generate(value: String): VillageId {
+            return VillageId(UUID.fromString(value))
         }
     }
 }

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/VillageRepository.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/VillageRepository.kt
@@ -15,6 +15,15 @@ interface VillageRepository {
     fun selectAllVillages(isRecruitedOnly: Boolean): List<Village>
 
     /**
+     * 村を取得する
+     *
+     * @param villageId 村ID
+     *
+     * @return 村
+     */
+    fun selectVillageById(villageId: VillageId): Pair<Village, HashedPassword>?
+
+    /**
      * 村を作成する
      * @condition ゲームマスターがすでにUserTableに作成されていること
      *

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/WerewolfErrorCode.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/WerewolfErrorCode.kt
@@ -1,0 +1,6 @@
+package com.example.backendkotlin.domain
+
+enum class WerewolfErrorCode(val code: String) {
+    VILLAGE_PASSWORD_IS_WRONG("VILLAGE_PASSWORD_IS_WRONG"),
+    RESOURCE_NOT_FOUND("RESOURCE_NOT_FOUND"),
+}

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/WerewolfException.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/domain/WerewolfException.kt
@@ -1,0 +1,15 @@
+package com.example.backendkotlin.domain
+
+/**
+ * 人狼ゲームアプリケーションの例外
+ *
+ * @param code エラーコード
+ * @param message エラーメッセージ
+ */
+data class WerewolfException(
+    val code: WerewolfErrorCode,
+    override val message: String,
+    override val cause: Throwable?,
+) : RuntimeException(message) {
+    constructor(code: WerewolfErrorCode, message: String) : this(code, message, null)
+}

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/presentation/GrpcServiceExceptionHandler.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/presentation/GrpcServiceExceptionHandler.kt
@@ -1,0 +1,29 @@
+package com.example.backendkotlin.presentation
+
+import com.example.backendkotlin.domain.WerewolfErrorCode
+import com.example.backendkotlin.domain.WerewolfException
+import com.google.protobuf.GeneratedMessage
+import io.grpc.Status
+import io.grpc.stub.StreamObserver
+
+interface GrpcServiceExceptionHandler {
+    fun <T : GeneratedMessage> handleException(responseObserver: StreamObserver<T>, action: () -> Unit) {
+        try {
+            action()
+        } catch (e: WerewolfException) {
+            when (e.code) {
+                WerewolfErrorCode.RESOURCE_NOT_FOUND -> {
+                    val message = "The village does not exist"
+                    responseObserver.onError(Status.NOT_FOUND.withDescription(message).asRuntimeException())
+                }
+                WerewolfErrorCode.VILLAGE_PASSWORD_IS_WRONG -> {
+                    val message = "The village password is wrong"
+                    responseObserver.onError(Status.INVALID_ARGUMENT.withDescription(message).asRuntimeException())
+                }
+            }
+        } catch (e: Exception) {
+            val message = "An error occurred"
+            responseObserver.onError(Status.UNKNOWN.withDescription(message).asRuntimeException())
+        }
+    }
+}

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/presentation/VillageGrpcService.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/presentation/VillageGrpcService.kt
@@ -12,6 +12,7 @@ import com.example.backendkotlin.generated.grpc.ListVillagesResponse
 import com.example.backendkotlin.generated.grpc.VillageResponse
 import com.example.backendkotlin.generated.grpc.VillageServiceGrpc
 import com.example.backendkotlin.usecase.CreateVillageUseCase
+import com.example.backendkotlin.usecase.EnterVillageUseCase
 import com.example.backendkotlin.usecase.GetCurrentVillageUsersUseCase
 import com.example.backendkotlin.usecase.ListVillagesUseCase
 import io.grpc.stub.StreamObserver
@@ -25,6 +26,7 @@ class VillageGrpcService(
     private val listVillagesUseCase: ListVillagesUseCase,
     private val createVillageUseCase: CreateVillageUseCase,
     private val getCurrentVillageUsersUseCase: GetCurrentVillageUsersUseCase,
+    private val enterVillageUseCase: EnterVillageUseCase,
 ) : VillageServiceGrpc.VillageServiceImplBase() {
     /**
      * 村を作成する
@@ -119,10 +121,20 @@ class VillageGrpcService(
      */
     override fun enterVillage(request: EnterVillageRequest, responseObserver: StreamObserver<EnterVillageResponse>) {
         // Todo: ユーザーが村に参加する処理を実装する
-        val enterVillageResponse = EnterVillageResponse.newBuilder()
-            .setVillageId("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
-            .setUserId("00000000-0000-0000-0000-000000000000")
-            .build()
+        val result = enterVillageUseCase.invoke(
+            villageIdString = request.villageId,
+            villagePassword = request.villagePassword,
+            userName = request.userName,
+            userPassword = request.userPassword,
+        )
+
+        // レスポンスを作成
+        val enterVillageResponse = result.let { (villageId, userId) ->
+            EnterVillageResponse.newBuilder()
+                .setVillageId(villageId.value.toString())
+                .setUserId(userId.value.toString())
+                .build()
+        }
         responseObserver.let { r ->
             r.onNext(enterVillageResponse)
             r.onCompleted()

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCase.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCase.kt
@@ -7,9 +7,9 @@ import com.example.backendkotlin.domain.UserId
 import com.example.backendkotlin.domain.UserRepository
 import com.example.backendkotlin.domain.VillageId
 import com.example.backendkotlin.domain.VillageRepository
-import com.example.backendkotlin.infrastructure.db.table.RUserVillageTable.userId
+import com.example.backendkotlin.domain.WerewolfErrorCode
+import com.example.backendkotlin.domain.WerewolfException
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 /**
  *  一般ユーザーが村にログインするユースケース
@@ -31,14 +31,14 @@ class EnterVillageUseCase(
      *
      * @return 村IDとユーザーID
      */
-    fun invoke(villageIdString: String, villagePassword: String, userName: String, userPassword: String): Pair<VillageId, UserId> {
+    fun invoke(villageIdString: String, villagePassword: String, userName: String, userPassword: String): Pair<UserId, VillageId> {
         // リクエストされた村が存在するか確認
-        val villageId = VillageId(UUID.fromString(villageIdString))
-        val villageAndHashedPassword = villageRepository.selectVillageById(villageId) ?: throw IllegalArgumentException("村が存在しません")
+        val villageId = VillageId.generate(villageIdString)
+        val villageAndHashedPassword = villageRepository.selectVillageById(villageId) ?: throw WerewolfException(WerewolfErrorCode.RESOURCE_NOT_FOUND, "村が存在しません")
 
         // 取得した村のパスワードが正しいか確認
-        if (HashedPassword.doesMatch(villagePassword, villageAndHashedPassword.second)) {
-            throw IllegalArgumentException("パスワードが違います")
+        if (!HashedPassword.doesMatch(villagePassword, villageAndHashedPassword.second)) {
+            throw WerewolfException(WerewolfErrorCode.VILLAGE_PASSWORD_IS_WRONG, "村のパスワードが違います")
         }
 
         // ユーザーを作成
@@ -52,9 +52,9 @@ class EnterVillageUseCase(
         userRepository.createUser(newUser, userHashedPassword)
 
         // ユーザーと村を紐付ける
-        rUserVillageRepository.save(userId, villageId)
+        val result = rUserVillageRepository.save(userId, villageId)
 
         // レスポンスを作成
-        return Pair(villageId, userId)
+        return result
     }
 }

--- a/backend-kotlin/src/main/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCase.kt
+++ b/backend-kotlin/src/main/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCase.kt
@@ -1,0 +1,54 @@
+package com.example.backendkotlin.usecase
+
+import com.example.backendkotlin.domain.HashedPassword
+import com.example.backendkotlin.domain.RUserVillageRepository
+import com.example.backendkotlin.domain.User
+import com.example.backendkotlin.domain.UserId
+import com.example.backendkotlin.domain.UserRepository
+import com.example.backendkotlin.domain.VillageId
+import com.example.backendkotlin.domain.VillageRepository
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ *  一般ユーザーが村にログインするユースケース
+ */
+@Service
+class EnterVillageUseCase(
+    private val villageRepository: VillageRepository,
+    private val userRepository: UserRepository,
+    private val rUserVillageRepository: RUserVillageRepository,
+) {
+
+    /**
+     * 一般ユーザーが村にログインする
+     *
+     * @param villageIdString 村ID
+     * @param villagePassword 村パスワード
+     * @param userName ユーザー名
+     * @param userPassword ユーザーパスワード
+     *
+     * @return 村IDとユーザーID
+     */
+    fun invoke(villageIdString: String, villagePassword: String, userName: String, userPassword: String): Pair<VillageId, UserId> {
+        // リクエストされた村が存在するか確認
+        val villageId = VillageId(UUID.fromString(villageIdString))
+        // villageRepository.findById(villageId)
+
+        // 取得した村のパスワードが正しいか確認
+        val userId = UserId.generate()
+
+        // ユーザーのパスワードを暗号化
+        val userHashedPassword = HashedPassword.create(userPassword)
+
+        // ユーザーを作成
+        val newUser = User(userId, userName, true)
+        userRepository.createUser(newUser, userHashedPassword)
+
+        // ユーザーと村を紐付ける
+        rUserVillageRepository.save(userId, villageId)
+
+        // レスポンスを作成
+        return Pair(villageId, userId)
+    }
+}

--- a/backend-kotlin/src/test/kotlin/com/example/backendkotlin/domain/VillageIdUT.kt
+++ b/backend-kotlin/src/test/kotlin/com/example/backendkotlin/domain/VillageIdUT.kt
@@ -1,6 +1,7 @@
 package com.example.backendkotlin.domain
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import java.util.UUID
 
@@ -20,11 +21,34 @@ class VillageIdUT : DescribeSpec() {
                 }
             }
         }
-        describe("generate") {
+
+        describe("generate()") {
             it("オブジェクトを生成できる") {
                 // when, then
                 shouldNotThrowAny {
                     VillageId.generate()
+                }
+            }
+        }
+
+        describe("generate(value: String)") {
+            it("UUIDの仕様に沿った文字列からオブジェクトを生成できる") {
+                // given
+                val value = "123e4567-e89b-12d3-a456-426614174000"
+
+                // when, then
+                shouldNotThrowAny {
+                    VillageId.generate(value)
+                }
+            }
+
+            it("UUIDの仕様に沿っていない文字列からオブジェクトを生成できない") {
+                // given
+                val value = "value"
+
+                // when, then
+                shouldThrow<IllegalArgumentException> {
+                    VillageId.generate(value)
                 }
             }
         }

--- a/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/CreateVillageUseCaseUT.kt
+++ b/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/CreateVillageUseCaseUT.kt
@@ -10,7 +10,7 @@ import com.example.backendkotlin.domain.VillageId
 import com.example.backendkotlin.domain.VillageRepository
 import com.example.backendkotlin.util.KSelect
 import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.Tuple2
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -40,11 +40,15 @@ class CreateVillageUseCaseUT(
     @InjectMockKs
     private lateinit var target: CreateVillageUseCase
 
-    override suspend fun beforeTest(testCase: TestCase) {
+    override suspend fun beforeSpec(spec: Spec) {
         mockkObject(UserId, VillageId, HashedPassword)
     }
 
-    override fun afterTest(f: suspend (Tuple2<TestCase, TestResult>) -> Unit) {
+    override suspend fun afterSpec(spec: Spec) {
+        unmockkObject(UserId, VillageId, HashedPassword)
+    }
+
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
         // テスト後にMockの挙動を初期化する
         confirmVerified(
             villageRepository,
@@ -52,7 +56,6 @@ class CreateVillageUseCaseUT(
             rUserVillageRepository,
         )
         clearAllMocks()
-        unmockkObject(UserId, VillageId, HashedPassword)
     }
 
     init {

--- a/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCaseUT.kt
+++ b/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/EnterVillageUseCaseUT.kt
@@ -1,0 +1,197 @@
+package com.example.backendkotlin.usecase
+
+import com.example.backendkotlin.domain.HashedPassword
+import com.example.backendkotlin.domain.RUserVillageRepository
+import com.example.backendkotlin.domain.User
+import com.example.backendkotlin.domain.UserId
+import com.example.backendkotlin.domain.UserRepository
+import com.example.backendkotlin.domain.Village
+import com.example.backendkotlin.domain.VillageId
+import com.example.backendkotlin.domain.VillageRepository
+import com.example.backendkotlin.domain.WerewolfErrorCode
+import com.example.backendkotlin.domain.WerewolfException
+import com.example.backendkotlin.util.KSelect
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.instancio.Instancio
+
+/**
+ * EnterVillageUseCaseのテストクラス
+ */
+class EnterVillageUseCaseUT(
+    @MockkBean
+    private val villageRepository: VillageRepository,
+
+    @MockkBean
+    private val userRepository: UserRepository,
+
+    @MockkBean
+    private val rUserVillageRepository: RUserVillageRepository,
+) : DescribeSpec() {
+    @InjectMockKs
+    private lateinit var target: EnterVillageUseCase
+
+    override suspend fun beforeSpec(spec: Spec) {
+        mockkObject(UserId, VillageId, HashedPassword)
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        unmockkObject(UserId, VillageId, HashedPassword)
+    }
+
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+        // テスト後にMockの挙動を初期化する
+        confirmVerified(
+            villageRepository,
+            userRepository,
+            rUserVillageRepository,
+        )
+        clearAllMocks()
+    }
+
+    init {
+        this.describe("invokeメソッドのテスト") {
+            context("正常系") {
+                it("村にログインする") {
+                    // given
+                    val gameMaserUserId = Instancio.create(UserId::class.java)
+
+                    val villageId = Instancio.create(VillageId::class.java)
+                    val villageName = "村1"
+                    val villageCitizenCount = 10
+                    val villageWerewolfCount = 2
+                    val villageFortuneTellerCount = 1
+                    val villageKnightCount = 1
+                    val villagePsychicCount = 1
+                    val villageMadmanCount = 1
+                    val villageIsInitialActionActive = true
+                    val village = Instancio.of(Village::class.java)
+                        .set(KSelect.field(Village::id), villageId)
+                        .set(KSelect.field(Village::name), villageName)
+                        .set(KSelect.field(Village::citizenCount), villageCitizenCount)
+                        .set(KSelect.field(Village::werewolfCount), villageWerewolfCount)
+                        .set(KSelect.field(Village::fortuneTellerCount), villageFortuneTellerCount)
+                        .set(KSelect.field(Village::knightCount), villageKnightCount)
+                        .set(KSelect.field(Village::psychicCount), villagePsychicCount)
+                        .set(KSelect.field(Village::madmanCount), villageMadmanCount)
+                        .set(KSelect.field(Village::isInitialActionActive), villageIsInitialActionActive)
+                        .set(KSelect.field(Village::gameMasterUserId), gameMaserUserId)
+                        .set(KSelect.field(Village::currentUserNumber), 1)
+                        .set(KSelect.field(Village::isRecruited), true)
+                        .create()
+
+                    val villagePassword = "village-password"
+                    val villageHashedPassword = Instancio.create(HashedPassword::class.java)
+                    val villageAndHashedPassword = Pair(village, villageHashedPassword)
+
+                    val newUserId = Instancio.create(UserId::class.java)
+                    val newUserName = "userName"
+                    val newUser = Instancio.of(User::class.java)
+                        .set(KSelect.field(User::id), newUserId)
+                        .set(KSelect.field(User::name), newUserName)
+                        .set(KSelect.field(User::isActive), true)
+                        .create()
+                    val newUserPassword = "user-password"
+                    val newUserHashedPassword = Instancio.create(HashedPassword::class.java)
+
+                    val expected = Pair(newUserId, villageId)
+
+                    // and
+                    every { VillageId.generate(villageId.value.toString()) } returns villageId
+                    every { villageRepository.selectVillageById(villageId) } returns villageAndHashedPassword
+                    every { HashedPassword.doesMatch(villagePassword, villageHashedPassword) } returns true
+                    every { UserId.generate() } returns newUserId
+                    every { HashedPassword.create(newUserPassword) } returns newUserHashedPassword
+                    every { userRepository.createUser(newUser, newUserHashedPassword) } returns newUser
+                    every { rUserVillageRepository.save(newUserId, villageId) } returns expected
+
+                    // when
+                    val actual = target.invoke(villageId.value.toString(), villagePassword, newUserName, newUserPassword)
+
+                    // then
+                    actual shouldBe expected
+                    verify(exactly = 1) {
+                        villageRepository.selectVillageById(villageId)
+                        HashedPassword.doesMatch(villagePassword, villageHashedPassword)
+                        UserId.generate()
+                        HashedPassword.create(newUserPassword)
+                        userRepository.createUser(newUser, newUserHashedPassword)
+                        rUserVillageRepository.save(newUserId, villageId)
+                    }
+                }
+            }
+            context("異常系") {
+                it("村が存在しない") {
+                    // given
+                    val villageId = Instancio.create(VillageId::class.java)
+
+                    // and
+                    every { VillageId.generate(villageId.value.toString()) } returns villageId
+                    every { villageRepository.selectVillageById(villageId) } returns null
+
+                    // when, then
+                    val exception = shouldThrow<WerewolfException> {
+                        target.invoke(villageId.value.toString(), "password", "userName", "password")
+                    }
+                    exception.message shouldBe "村が存在しません"
+
+                    verify(exactly = 1) {
+                        villageRepository.selectVillageById(villageId)
+                    }
+                    verify(exactly = 0) {
+                        HashedPassword.doesMatch(any(), any())
+                        UserId.generate()
+                        HashedPassword.create(any())
+                        userRepository.createUser(any(), any())
+                        rUserVillageRepository.save(any(), any())
+                    }
+                }
+                it("パスワードが違う") {
+                    // given
+                    val villageId = Instancio.create(VillageId::class.java)
+                    val village = Instancio.create(Village::class.java)
+                    val incorrectVillagePassword = "password"
+                    val villageHashedPassword = Instancio.create(HashedPassword::class.java)
+                    val villageAndHashedPassword = Pair(village, villageHashedPassword)
+
+                    // and
+                    every { VillageId.generate(villageId.value.toString()) } returns villageId
+                    every { villageRepository.selectVillageById(villageId) } returns villageAndHashedPassword
+                    every { HashedPassword.doesMatch(incorrectVillagePassword, villageHashedPassword) } returns false
+
+                    // when, then
+                    val exception = shouldThrow<WerewolfException> {
+                        target.invoke(villageId.value.toString(), incorrectVillagePassword, "userName", "password")
+                    }
+
+                    // then
+                    exception.code shouldBe WerewolfErrorCode.VILLAGE_PASSWORD_IS_WRONG
+                    exception.message shouldBe "村のパスワードが違います"
+
+                    verify(exactly = 1) {
+                        villageRepository.selectVillageById(villageId)
+                        HashedPassword.doesMatch(incorrectVillagePassword, villageHashedPassword)
+                    }
+                    verify(exactly = 0) {
+                        UserId.generate()
+                        HashedPassword.create(any())
+                        userRepository.createUser(any(), any())
+                        rUserVillageRepository.save(any(), any())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/ListVillagesUseCaseUT.kt
+++ b/backend-kotlin/src/test/kotlin/com/example/backendkotlin/usecase/ListVillagesUseCaseUT.kt
@@ -5,7 +5,6 @@ import com.example.backendkotlin.domain.Village
 import com.example.backendkotlin.domain.VillageRepository
 import com.example.backendkotlin.util.KSelect
 import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.Tuple2
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -27,7 +26,7 @@ class ListVillagesUseCaseUT(
     @InjectMockKs
     private lateinit var target: ListVillagesUseCase
 
-    override fun afterTest(f: suspend (Tuple2<TestCase, TestResult>) -> Unit) {
+    override suspend fun afterTest(testCase: TestCase, result: TestResult) {
         // テスト後にMockの挙動を初期化する
         confirmVerified(villageRepository)
         clearAllMocks()


### PR DESCRIPTION
-Issue-40の後にmergeしてください。-

https://nadepoko.atlassian.net/wiki/spaces/SD/pages/74121248/EnterVillage の仕様に合わせて実装。


(村の作成)
`grpcurl --plaintext -d '{"name": "test", "citizen_count": 5, "werewolf_count": 1, "fortune_teller_count": 1, "knight_count": 1, "psychic_count": 0, "madman_count": 1, "is_initial_action_active": false, "password": "test", "game_master_name": "game-master", "game_master_password": "game-master-password"}' localhost:9090 village.VillageService/CreateVillage`

```
{
  "id": "930f9ada-d616-4118-a8d8-0fc429306de4",
  "name": "test",
  "user_number": 9,
  "citizen_count": 5,
  "werewolf_count": 1,
  "fortune_teller_count": 1,
  "knight_count": 1,
  "madman_count": 1,
  "game_master_user_id": "04d70601-b02d-486a-8f65-527680450f8d",
  "current_user_number": 1
}
```


EnterVillage実行
`grpcurl --plaintext -d '{"village_id": "930f9ada-d616-4118-a8d8-0fc429306de4", "village_password": "test", "user_name": "tsuchiya", "user_password": "password"}' localhost:9090 village.VillageService/EnterVillage`

```
{
  "village_id": "930f9ada-d616-4118-a8d8-0fc429306de4",
  "user_id": "b419a969-e24d-4662-bad0-99549befa11c"
}
```

成功していることを確認した。

DBにも意図したデータが登録されていることを確認。

`werewolf=# select * from "user";`

```
                  id                  |    name     |                        password_hash                         | is_active
--------------------------------------+-------------+--------------------------------------------------------------+-----------
 04d70601-b02d-486a-8f65-527680450f8d | game-master | $2a$10$3D5vX6gTahZe2NXDmlaP8.0dezadNtdCgSz309O1jQZb1TB2NaeKG | t
 b419a969-e24d-4662-bad0-99549befa11c | tsuchiya    | $2a$10$Nje0Il4Jp5wSz9oqgXk8RebcaisHHqhYIziSXIemy.46Fi/2K5v5q | t
```