### PR TITLE
issue-67 domain で int32 や *string を使っている箇所の撲滅

### DIFF
--- a/werewolf-cli/pkg/client/createvillage/mockclient.go
+++ b/werewolf-cli/pkg/client/createvillage/mockclient.go
@@ -19,7 +19,7 @@ func (m *MockVillageCreator) createVillage(request CreateVillageRequest) (*domai
 	hashString := fmt.Sprintf("%x", hash)
 
 	return &domain.Village{
-		Id:                    &hashString,
+		Id:                    hashString,
 		Name:                  request.Name,
 		CitizenCount:          request.CitizenCount,
 		WerewolfCount:         request.WerewolfCount,

--- a/werewolf-cli/pkg/client/createvillage/mockclient_test.go
+++ b/werewolf-cli/pkg/client/createvillage/mockclient_test.go
@@ -32,8 +32,8 @@ func TestSuccess(t *testing.T) {
 
 	// then:
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "ffd8a8822eddbac951b1ece03fcbd3623c56d8d8d532aa945dd9970406cf1efd", *actual.Id)
-	assert.Equal(t, *req.Name, *actual.Name)
+	assert.Equal(t, "ffd8a8822eddbac951b1ece03fcbd3623c56d8d8d532aa945dd9970406cf1efd", actual.Id)
+	assert.Equal(t, *req.Name, actual.Name)
 	assert.Equal(t, req.CitizenCount, actual.CitizenCount)
 	assert.Equal(t, req.WerewolfCount, actual.WerewolfCount)
 	assert.Equal(t, req.FortuneTellerCount, actual.FortuneTellerCount)

--- a/werewolf-cli/pkg/client/createvillage/village_creator.go
+++ b/werewolf-cli/pkg/client/createvillage/village_creator.go
@@ -3,17 +3,17 @@ package client
 import "github.com/pokotsun/werewolf-game/pkg/domain"
 
 type CreateVillageRequest struct {
-	Name                  *string
-	CitizenCount          int32
-	WerewolfCount         int32
-	FortuneTellerCount    int32
-	KnightCount           int32
-	PsychicCount          int32
-	MadmanCount           int32
+	Name                  string
+	CitizenCount          int
+	WerewolfCount         int
+	FortuneTellerCount    int
+	KnightCount           int
+	PsychicCount          int
+	MadmanCount           int
 	IsInitialActionActive bool
-	Password              *string
-	GameMasterName        *string
-	GameMasterPassword    *string
+	Password              string
+	GameMasterName        string
+	GameMasterPassword    string
 }
 
 type VillageCreator interface {

--- a/werewolf-cli/pkg/client/entervillage/mockclient_test.go
+++ b/werewolf-cli/pkg/client/entervillage/mockclient_test.go
@@ -14,10 +14,10 @@ func TestSuccess(t *testing.T) {
 	userName := "GameMaster"
 	userPassword := "GameMasterPassword"
 	req := EnterVillageRequest{
-		VillageId:       &villageId,
-		VillagePassword: &villagePassword,
-		UserName:        &userName,
-		UserPassword:    &userPassword,
+		VillageId:       villageId,
+		VillagePassword: villagePassword,
+		UserName:        userName,
+		UserPassword:    userPassword,
 	}
 
 	// when:

--- a/werewolf-cli/pkg/client/entervillage/village_joiner.go
+++ b/werewolf-cli/pkg/client/entervillage/village_joiner.go
@@ -1,10 +1,10 @@
 package client
 
 type EnterVillageRequest struct {
-	VillageId       *string
-	VillagePassword *string
-	UserName        *string
-	UserPassword    *string
+	VillageId       string
+	VillagePassword string
+	UserName        string
+	UserPassword    string
 }
 
 type EnterVillageResponse struct {

--- a/werewolf-cli/pkg/client/village_creator_impl_test.go
+++ b/werewolf-cli/pkg/client/village_creator_impl_test.go
@@ -39,7 +39,7 @@ func TestSuccessOnVillageCreatorServerIntegration(t *testing.T) {
 	gameMasterName := "GameMaster"
 	gameMasterPassword := "GameMasterPassword"
 	req := serverClient.CreateVillageRequest{
-		Name:                  &name,
+		Name:                  name,
 		CitizenCount:          7,
 		WerewolfCount:         2,
 		FortuneTellerCount:    1,
@@ -47,9 +47,9 @@ func TestSuccessOnVillageCreatorServerIntegration(t *testing.T) {
 		PsychicCount:          1,
 		MadmanCount:           1,
 		IsInitialActionActive: true,
-		Password:              &password,
-		GameMasterName:        &gameMasterName,
-		GameMasterPassword:    &gameMasterPassword,
+		Password:              password,
+		GameMasterName:        gameMasterName,
+		GameMasterPassword:    gameMasterPassword,
 	}
 
 	// when:
@@ -64,13 +64,13 @@ func TestSuccessOnVillageCreatorServerIntegration(t *testing.T) {
 	}
 
 	// レスポンスを表示
-	assert.Equal(t, name, *res.Name)
-	assert.Equal(t, int32(7), res.CitizenCount)
-	assert.Equal(t, int32(2), res.WerewolfCount)
-	assert.Equal(t, int32(1), res.FortuneTellerCount)
-	assert.Equal(t, int32(1), res.KnightCount)
-	assert.Equal(t, int32(1), res.PsychicCount)
-	assert.Equal(t, int32(1), res.MadmanCount)
+	assert.Equal(t, name, res.Name)
+	assert.Equal(t, 7, res.CitizenCount)
+	assert.Equal(t, 2, res.WerewolfCount)
+	assert.Equal(t, 1, res.FortuneTellerCount)
+	assert.Equal(t, 1, res.KnightCount)
+	assert.Equal(t, 1, res.PsychicCount)
+	assert.Equal(t, 1, res.MadmanCount)
 	assert.Equal(t, true, res.IsInitialActionActive)
-	assert.Equal(t, int32(1), res.CurrentUserNumber)
+	assert.Equal(t, 1, res.CurrentUserNumber)
 }

--- a/werewolf-cli/pkg/client/village_joiner_impl_test.go
+++ b/werewolf-cli/pkg/client/village_joiner_impl_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+// +build integration
+
+package client
+
+import (
+	"context"
+	"github.com/pokotsun/werewolf-game/pkg/client/entervillage"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"log"
+	"testing"
+	"time"
+)
+
+func TestSuccessOnVillageJoinerServerIntegration(t *testing.T) {
+	// given:
+	// コンテキストを作成し、タイムアウトを設定
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	// grpc.DialContext を使用して接続を確立
+	conn, err := grpc.DialContext(ctx, "localhost:9090", grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer func(conn *grpc.ClientConn) {
+		err := conn.Close()
+		if err != nil {
+			log.Fatalf("could not close connection: %v", err)
+		}
+	}(conn)
+
+	c := NewWerewolfServerClient(conn)
+
+	req := client.EnterVillageRequest{
+		VillageId:       "814611f7-06fa-4c59-ba5c-67bf686588b4",
+		VillagePassword: "test",
+		UserName:        "Test User",
+		UserPassword:    "test",
+	}
+
+	// when:
+	villageId, _, err := c.EnterVillage(req)
+	if err != nil {
+		log.Fatalf("could not get village info: %v", err)
+	}
+
+	// レスポンスを表示
+	assert.Equal(t, "814611f7-06fa-4c59-ba5c-67bf686588b4", villageId)
+}

--- a/werewolf-cli/pkg/client/werewolf_server_client.go
+++ b/werewolf-cli/pkg/client/werewolf_server_client.go
@@ -25,17 +25,17 @@ func NewWerewolfServerClient(conn *grpc.ClientConn) *WerewolfServerClient {
 
 func (c *WerewolfServerClient) CreateVillage(request client.CreateVillageRequest) (*domain.Village, error) {
 	req := village.CreateVillageRequest{
-		Name:                  *request.Name,
-		CitizenCount:          request.CitizenCount,
-		WerewolfCount:         request.WerewolfCount,
-		FortuneTellerCount:    request.FortuneTellerCount,
-		KnightCount:           request.KnightCount,
-		PsychicCount:          request.PsychicCount,
-		MadmanCount:           request.MadmanCount,
+		Name:                  request.Name,
+		CitizenCount:          int32(request.CitizenCount),
+		WerewolfCount:         int32(request.WerewolfCount),
+		FortuneTellerCount:    int32(request.FortuneTellerCount),
+		KnightCount:           int32(request.KnightCount),
+		PsychicCount:          int32(request.PsychicCount),
+		MadmanCount:           int32(request.MadmanCount),
 		IsInitialActionActive: request.IsInitialActionActive,
-		Password:              *request.Password,
-		GameMasterName:        *request.GameMasterName,
-		GameMasterPassword:    *request.GameMasterPassword,
+		Password:              request.Password,
+		GameMasterName:        request.GameMasterName,
+		GameMasterPassword:    request.GameMasterPassword,
 	}
 
 	// コンテキストを作成し、タイムアウトを設定
@@ -49,16 +49,16 @@ func (c *WerewolfServerClient) CreateVillage(request client.CreateVillageRequest
 	}
 
 	response := domain.Village{
-		Id:                    &res.Id,
-		Name:                  &res.Name,
-		CitizenCount:          res.CitizenCount,
-		WerewolfCount:         res.WerewolfCount,
+		Id:                    res.Id,
+		Name:                  res.Name,
+		CitizenCount:          int(res.CitizenCount),
+		WerewolfCount:         int(res.WerewolfCount),
 		FortuneTellerCount:    request.FortuneTellerCount,
 		KnightCount:           request.KnightCount,
 		PsychicCount:          request.PsychicCount,
 		MadmanCount:           request.MadmanCount,
 		IsInitialActionActive: true,
-		CurrentUserNumber:     res.CurrentUserNumber,
+		CurrentUserNumber:     int(res.CurrentUserNumber),
 	}
 
 	return &response, nil
@@ -79,16 +79,16 @@ func (c *WerewolfServerClient) ListVillages() ([]*domain.Village, error) {
 	var targetList []*domain.Village
 	for _, villageResponse := range res.Villages {
 		target := domain.Village{
-			Id:                    &villageResponse.Id,
-			Name:                  &villageResponse.Name,
-			CitizenCount:          villageResponse.CitizenCount,
-			WerewolfCount:         villageResponse.WerewolfCount,
-			FortuneTellerCount:    villageResponse.FortuneTellerCount,
-			KnightCount:           villageResponse.KnightCount,
-			PsychicCount:          villageResponse.PsychicCount,
-			MadmanCount:           villageResponse.MadmanCount,
+			Id:                    villageResponse.Id,
+			Name:                  villageResponse.Name,
+			CitizenCount:          int(villageResponse.CitizenCount),
+			WerewolfCount:         int(villageResponse.WerewolfCount),
+			FortuneTellerCount:    int(villageResponse.FortuneTellerCount),
+			KnightCount:           int(villageResponse.KnightCount),
+			PsychicCount:          int(villageResponse.PsychicCount),
+			MadmanCount:           int(villageResponse.MadmanCount),
 			IsInitialActionActive: true,
-			CurrentUserNumber:     villageResponse.CurrentUserNumber,
+			CurrentUserNumber:     int(villageResponse.CurrentUserNumber),
 		}
 		targetList = append(targetList, &target)
 	}
@@ -102,10 +102,10 @@ func (c *WerewolfServerClient) EnterVillage(request client2.EnterVillageRequest)
 	defer cancel()
 
 	req := village.EnterVillageRequest{
-		VillageId:       *request.VillageId,
-		VillagePassword: *request.VillagePassword,
-		UserName:        *request.UserName,
-		UserPassword:    *request.UserPassword,
+		VillageId:       request.VillageId,
+		VillagePassword: request.VillagePassword,
+		UserName:        request.UserName,
+		UserPassword:    request.UserPassword,
 	}
 
 	// サーバーにリクエストを送信

--- a/werewolf-cli/pkg/domain/Village.go
+++ b/werewolf-cli/pkg/domain/Village.go
@@ -1,18 +1,18 @@
 package domain
 
 type Village struct {
-	Id                    *string
-	Name                  *string
-	CitizenCount          int32
-	WerewolfCount         int32
-	FortuneTellerCount    int32
-	KnightCount           int32
-	PsychicCount          int32
-	MadmanCount           int32
+	Id                    string
+	Name                  string
+	CitizenCount          int
+	WerewolfCount         int
+	FortuneTellerCount    int
+	KnightCount           int
+	PsychicCount          int
+	MadmanCount           int
 	IsInitialActionActive bool
-	CurrentUserNumber     int32
+	CurrentUserNumber     int
 }
 
-func (v *Village) GetTotalMemberCount() int32 {
+func (v *Village) GetTotalMemberCount() int {
 	return v.CitizenCount + v.WerewolfCount + v.FortuneTellerCount + v.KnightCount + v.PsychicCount + v.MadmanCount
 }

--- a/werewolf-cli/pkg/domain/Village_test.go
+++ b/werewolf-cli/pkg/domain/Village_test.go
@@ -1,0 +1,25 @@
+package domain
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSuccessOnCurrentVillageNumbers(t *testing.T) {
+	// given:
+	village := Village{
+		CitizenCount:       10,
+		WerewolfCount:      2,
+		FortuneTellerCount: 1,
+		KnightCount:        1,
+		PsychicCount:       1,
+		MadmanCount:        1,
+		CurrentUserNumber:  1,
+	}
+
+	// when:
+	actual := village.GetTotalMemberCount()
+
+	expected := 16
+	assert.Equal(t, expected, actual)
+}

--- a/werewolf-cli/ui/components/createvillage/createvillage.go
+++ b/werewolf-cli/ui/components/createvillage/createvillage.go
@@ -160,15 +160,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 						// Create village
 						req := client.CreateVillageRequest{
-							Name:               &villageName,
-							CitizenCount:       int32(citizenCount),
-							WerewolfCount:      int32(werewolfCount),
-							FortuneTellerCount: int32(fortuneTellerCount),
-							KnightCount:        int32(knightCount),
-							MadmanCount:        int32(madmanCount),
-							Password:           &villagePassword,
-							GameMasterName:     &gameMasterName,
-							GameMasterPassword: &gameMasterPassword,
+							Name:               villageName,
+							CitizenCount:       citizenCount,
+							WerewolfCount:      werewolfCount,
+							FortuneTellerCount: fortuneTellerCount,
+							KnightCount:        knightCount,
+							MadmanCount:        madmanCount,
+							Password:           villagePassword,
+							GameMasterName:     gameMasterName,
+							GameMasterPassword: gameMasterPassword,
 						}
 						v, err := m.ctx.WerewolfClient.CreateVillage(req)
 						if err != nil {
@@ -181,12 +181,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						msg := Msg{
 							Village: domain.Village{
 								Id:                    v.Id,
-								Name:                  &villageName,
-								CitizenCount:          int32(citizenCount),
-								WerewolfCount:         int32(werewolfCount),
-								FortuneTellerCount:    int32(fortuneTellerCount),
-								KnightCount:           int32(knightCount),
-								MadmanCount:           int32(madmanCount),
+								Name:                  villageName,
+								CitizenCount:          citizenCount,
+								WerewolfCount:         werewolfCount,
+								FortuneTellerCount:    fortuneTellerCount,
+								KnightCount:           knightCount,
+								MadmanCount:           madmanCount,
 								IsInitialActionActive: true,
 							},
 							VillagePassword:    villagePassword,
@@ -194,7 +194,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							GameMasterPassword: gameMasterPassword,
 						}
 
-						m.errorMsg = errormsg.NewErrorMessage("Village: " + *v.Id + " created successfully!")
+						m.errorMsg = errormsg.NewErrorMessage("Village: " + v.Id + " created successfully!")
 						return loggertype.LogMsg{
 							Entry: loggertype.LogEntry{
 								Message: fmt.Sprintf("Village %v created successfully!", msg.Village.Id),

--- a/werewolf-cli/ui/components/listvillages/listvillages.go
+++ b/werewolf-cli/ui/components/listvillages/listvillages.go
@@ -21,7 +21,7 @@ type item struct {
 }
 
 func (i item) Title() string {
-	return fmt.Sprintf("%s", *i.Name)
+	return fmt.Sprintf("%s", i.Name)
 }
 
 func (i item) Description() string {
@@ -46,7 +46,7 @@ func (i item) Description() string {
 }
 
 func (i item) FilterValue() string {
-	return *i.Name
+	return i.Name
 }
 
 type Model struct {


### PR DESCRIPTION
 grpc-client が指定する型に引きずられて int32 や *string を使ってましたが、不便なだけなので int や string を使うことにします
string のコピーが走ってパフォーマンス上問題が出そうな個所は struct 側で対処することにします

ついでに細かいテストの追加やリファクタを入れてます
